### PR TITLE
fix: correctly handle unshuffleable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Once you are happy with the resulting ids, persist the preflight-expectation tab
 With explicit config:
 
 ```sh
-./dist/phonid*/phonid 4711 --rcfile .phonidrc.toml
+./dist/phonid*/phonid 4711 --config .phonidrc.toml
 ```
 
 ## License

--- a/cmd/phonid/root.go
+++ b/cmd/phonid/root.go
@@ -26,7 +26,7 @@ phonetic patterns and optional Feistel shuffling.`,
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "rcfile", "", "config file (default: search for .phonidrc)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: search for .phonidrc)")
 	rootCmd.AddCommand(preflightCmd)
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -452,7 +452,7 @@ type PatternEncoder struct {
 ```
 
 <a name="PatternEncoder.Decode"></a>
-### func \(\*PatternEncoder\) [Decode](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L282>)
+### func \(\*PatternEncoder\) [Decode](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L297>)
 
 ```go
 func (e *PatternEncoder) Decode(word string) (PositiveInt, error)
@@ -461,7 +461,7 @@ func (e *PatternEncoder) Decode(word string) (PositiveInt, error)
 Decode converts a phonetic word back to a number. Returns PositiveInt which can represent both small and large values.
 
 <a name="PatternEncoder.Encode"></a>
-### func \(\*PatternEncoder\) [Encode](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L255>)
+### func \(\*PatternEncoder\) [Encode](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L270>)
 
 ```go
 func (e *PatternEncoder) Encode(number PositiveInt) (string, error)
@@ -470,7 +470,7 @@ func (e *PatternEncoder) Encode(number PositiveInt) (string, error)
 Encode converts a number to a phonetic word. Uses optimized int64 arithmetic for small numbers, big.Int for large numbers.
 
 <a name="PatternEncoder.MaxValue"></a>
-### func \(\*PatternEncoder\) [MaxValue](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L303>)
+### func \(\*PatternEncoder\) [MaxValue](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L318>)
 
 ```go
 func (e *PatternEncoder) MaxValue() int
@@ -517,7 +517,7 @@ func NewPhoneticEncoderSkipPreflight(config *PhonidConfig) (*PhoneticEncoder, er
 NewPhoneticEncoderSkipPreflight creates an encoder without preflight validation. Only use this when preflight checks are genuinely unavailable \(e.g., testing scenarios\).
 
 <a name="PhoneticEncoder.Decode"></a>
-### func \(\*PhoneticEncoder\) [Decode](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L232>)
+### func \(\*PhoneticEncoder\) [Decode](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L247>)
 
 ```go
 func (e *PhoneticEncoder) Decode(word string) (PositiveInt, error)
@@ -535,7 +535,7 @@ func (e *PhoneticEncoder) Encode(number PositiveInt) (string, error)
 Encode converts a number to a phonetic word, automatically selecting the best pattern. The number can be either a native int64 or a big.Int, with automatic optimization.
 
 <a name="PhoneticEncoder.GetPatternInfo"></a>
-### func \(\*PhoneticEncoder\) [GetPatternInfo](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L327-L332>)
+### func \(\*PhoneticEncoder\) [GetPatternInfo](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L342-L347>)
 
 ```go
 func (e *PhoneticEncoder) GetPatternInfo() []struct {
@@ -549,7 +549,7 @@ func (e *PhoneticEncoder) GetPatternInfo() []struct {
 GetPatternInfo returns information about all patterns for generating suggestions. Returns a slice with pattern details including true mathematical capacity. Each pattern can encode numbers from 0 to its TrueCapacity\-1. Capacity field is capped at math.MaxInt for compatibility, while TrueCapacity shows the real limit.
 
 <a name="PhoneticEncoder.GetSmallestPatternCapacity"></a>
-### func \(\*PhoneticEncoder\) [GetSmallestPatternCapacity](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L316>)
+### func \(\*PhoneticEncoder\) [GetSmallestPatternCapacity](<https://github.com/iilei/phonid/blob/master/pkg/encode.go#L331>)
 
 ```go
 func (e *PhoneticEncoder) GetSmallestPatternCapacity() int
@@ -856,6 +856,24 @@ Package preflight provides preflight check generation and formatting.
 ```go
 const (
     LocalhostDecimal = 2130706433
+
+    ConfigHeaderComment = `
+Pattern Requirements:
+  - Pattern Length: Must be 5, 7, 11, 23, 29, 31, 37, 41, 43, or 47 characters
+    (e.g., CVCVC, CVCVCVC)
+  - Vowels (V): Length 5 needs ≥3 vowels; length 7+ needs ≥2 vowels
+  - Consonants (C): Need ≥3 characters (e.g., "bzk" or "bdfghjklmnprstvz")
+  - Shuffling: Ensure 128+ combinations for shuffle rounds ≥ 1 (automatically validated)
+
+Available Placeholders:
+  C = Consonants, V = Vowels, L = Liquids (l,m,n,r)
+  N = Nasals, S = Sibilants, F = Fricatives
+  X/Y/Z = Custom categories
+
+Shuffle Limitations:
+  Patterns with capacity > 18,446,744,073,709,551,615 (uint64 max) cannot be shuffled.
+  Shuffling will be automatically disabled for such patterns, and values will be
+  encoded in sequential order without permutation.`
 )
 ```
 
@@ -878,7 +896,7 @@ func SuggestConfig(encoder *phonid.PhoneticEncoder, config *phonid.PhonidConfig)
 SuggestConfig generates a complete TOML configuration string with preflight suggestions. It includes the base config, shuffle settings, phonetic patterns, and suggested test assertions with inline comments preserved. If encoder is nil, creates a default encoder. If config is nil, uses DefaultConfig.
 
 <a name="Assertion"></a>
-## type [Assertion](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L20-L24>)
+## type [Assertion](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L37-L41>)
 
 Assertion represents a single suggested preflight check.
 
@@ -891,7 +909,7 @@ type Assertion struct {
 ```
 
 <a name="AssertionTable"></a>
-## type [AssertionTable](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L26>)
+## type [AssertionTable](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L43>)
 
 AssertionTable represents a collection of preflight check assertions.
 
@@ -900,7 +918,7 @@ type AssertionTable []Assertion
 ```
 
 <a name="GenerateSuggestions"></a>
-### func [GenerateSuggestions](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L32>)
+### func [GenerateSuggestions](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L49>)
 
 ```go
 func GenerateSuggestions(encoder *phonid.PhoneticEncoder) (AssertionTable, error)
@@ -909,7 +927,7 @@ func GenerateSuggestions(encoder *phonid.PhoneticEncoder) (AssertionTable, error
 GenerateSuggestions creates preflight check suggestions for an encoder. It generates boundary values and representative test points across the encoding space. If encoder is nil, creates a default encoder using ProQuint configuration.
 
 <a name="GenerateSuggestionsWithCustom"></a>
-### func [GenerateSuggestionsWithCustom](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L41-L45>)
+### func [GenerateSuggestionsWithCustom](<https://github.com/iilei/phonid/blob/master/pkg/preflight/suggest.go#L58-L62>)
 
 ```go
 func GenerateSuggestionsWithCustom(encoder *phonid.PhoneticEncoder, customValues []phonid.PositiveInt, includeBoundaries bool) (AssertionTable, error)
@@ -930,7 +948,7 @@ type Formatter interface {
 ```
 
 <a name="NewGoFormatter"></a>
-### func [NewGoFormatter](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L14>)
+### func [NewGoFormatter](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L21>)
 
 ```go
 func NewGoFormatter() Formatter
@@ -995,16 +1013,23 @@ func (r *FormatterRegistry) Register(formatter Formatter)
 Register adds a formatter to the registry.
 
 <a name="GoFormatter"></a>
-## type [GoFormatter](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L11>)
+## type [GoFormatter](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L18>)
 
-GoFormatter implements the Formatter interface for Go code output.
+GoFormatter implements the Formatter interface for Go code output. Note: This formatter only outputs preflight assertions, not configuration. For full configuration including shuffle settings, use the TOML formatter.
+
+Shuffle Limitations:
+
+```
+Patterns with capacity > 18,446,744,073,709,551,615 (uint64 max) cannot be shuffled.
+When using such patterns, shuffle configuration should be omitted entirely.
+```
 
 ```go
 type GoFormatter struct{}
 ```
 
 <a name="GoFormatter.Format"></a>
-### func \(\*GoFormatter\) [Format](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L24>)
+### func \(\*GoFormatter\) [Format](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L31>)
 
 ```go
 func (f *GoFormatter) Format(w io.Writer, assertions *AssertionTable) error
@@ -1013,7 +1038,7 @@ func (f *GoFormatter) Format(w io.Writer, assertions *AssertionTable) error
 Format writes preflight assertions as Go code to the writer.
 
 <a name="GoFormatter.Name"></a>
-### func \(\*GoFormatter\) [Name](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L19>)
+### func \(\*GoFormatter\) [Name](<https://github.com/iilei/phonid/blob/master/pkg/preflight/goformat.go#L26>)
 
 ```go
 func (f *GoFormatter) Name() OutputFormat
@@ -1070,7 +1095,7 @@ TOMLConfig represents the full .phonidrc TOML structure.
 
 ```go
 type TOMLConfig struct {
-    Shuffle   ShuffleConfig  `toml:"shuffle"`
+    Shuffle   *ShuffleConfig `toml:"shuffle,omitempty"` // Omitted if capacity > uint64 max
     Phonetic  PhoneticConfig `toml:"phonetic"`
     Preflight []Assertion    `toml:"preflight"`
 }

--- a/pkg/encode.go
+++ b/pkg/encode.go
@@ -201,23 +201,38 @@ func (e *PhoneticEncoder) Encode(number PositiveInt) (string, error) {
 		return "", err
 	}
 
-	// Apply shuffling if configured (requires fitting in uint64)
+	// CRITICAL: Validate input against pattern capacity BEFORE shuffling
+	// This ensures consistent maximum value regardless of shuffle configuration.
+	// Cycle walking in applyShuffle() will keep the shuffled value within this capacity.
+	maxCapacity := e.patternEncoders[len(e.patternEncoders)-1].totalCombinations
+	if number.BigInt().Cmp(maxCapacity) >= 0 {
+		maxValue := new(big.Int).Sub(maxCapacity, big.NewInt(1))
+		var displayMax string
+		if maxValue.Cmp(big.NewInt(int64(math.MaxInt))) > 0 {
+			displayMax = fmt.Sprintf(">%d", math.MaxInt)
+		} else {
+			displayMax = maxValue.String()
+		}
+		return "", fmt.Errorf("number %s exceeds largest pattern capacity (max value: %s)",
+			number.String(), displayMax)
+	}
+
+	// Apply shuffling if configured (uses cycle walking for format-preserving encryption)
 	encodedNumber, err := e.applyShuffle(number)
 	if err != nil {
 		return "", err
 	}
 
-	// Find the smallest pattern that can encode this number
+	// Find the smallest pattern that can encode this shuffled number
+	// After cycle walking, encodedNumber is guaranteed to be < maxCapacity
 	for _, pattern := range e.patternEncoders {
 		if encodedNumber.BigInt().Cmp(pattern.totalCombinations) < 0 {
 			return pattern.Encode(encodedNumber)
 		}
 	}
 
-	// Number too large for any pattern
-	maxCapacity := e.patternEncoders[len(e.patternEncoders)-1].totalCombinations
-	// For display, limit to MaxInt if capacity is larger
-	// Calculate max value (capacity - 1) for error message
+	// This should never be reached due to input validation and cycle walking,
+	// but keep as a safety net for defensive programming
 	maxValue := new(big.Int).Sub(maxCapacity, big.NewInt(1))
 	var displayMax string
 	if maxValue.Cmp(big.NewInt(int64(math.MaxInt))) > 0 {
@@ -368,15 +383,38 @@ func (e *PhoneticEncoder) GetPatternInfo() []struct {
 }
 
 // applyShuffle applies Feistel shuffling to the input number if configured.
-// Returns the shuffled number, or the original if no shuffler is configured.
+// Uses cycle walking (format-preserving encryption) to ensure the output stays
+// within the pattern capacity even when capacity is not a power of 2.
+//
+// Cycle walking works by repeatedly shuffling values that fall outside the valid
+// range until we get a value within range. This maintains bijectivity: each input
+// maps to exactly one output, and the mapping is reversible.
+//
+// Example: Pattern capacity 243, shuffler operates on 8-bit (0-255)
+//   - Input: 241 → Shuffle → 250 (invalid, ≥243) → Shuffle → 180 (valid) ✓
+//   - On decode: 180 → Unshuffle → 250 → Unshuffle → 241 ✓
+//
+// Note: If pattern capacity exceeds uint64, shuffling is not supported.
 func (e *PhoneticEncoder) applyShuffle(number PositiveInt) (PositiveInt, error) {
 	if e.shuffler == nil {
 		return number, nil
 	}
 
+	// Get maximum capacity for cycle walking
+	maxCapacity := e.patternEncoders[len(e.patternEncoders)-1].totalCombinations
+	maxUint64 := new(big.Int).SetUint64(math.MaxUint64)
+
+	// Check if capacity exceeds uint64 range
+	// If so, shuffling is not supported (Feistel networks require uint64 domain)
+	if maxCapacity.Cmp(maxUint64) > 0 {
+		// For very large patterns, we can't use shuffling with cycle walking
+		// Return the input unchanged (as if no shuffler was configured)
+		return number, nil
+	}
+	maxCapacityUint64 := maxCapacity.Uint64()
+
 	// Check if number fits in uint64 for shuffling
 	bigVal := number.BigInt()
-	maxUint64 := new(big.Int).SetUint64(math.MaxUint64)
 
 	if bigVal.Cmp(maxUint64) > 0 {
 		return nil, fmt.Errorf("number too large for shuffling (max: %d)", uint64(math.MaxUint64))
@@ -391,9 +429,33 @@ func (e *PhoneticEncoder) applyShuffle(number PositiveInt) (PositiveInt, error) 
 		val = bigVal.Uint64()
 	}
 
-	shuffled, err := e.shuffler.Encode(val)
-	if err != nil {
-		return nil, fmt.Errorf("shuffle failed: %w", err)
+	// Cycle walking: repeatedly shuffle until we get a value within capacity
+	// This implements format-preserving encryption for non-power-of-2 domains
+	shuffled := val
+	const maxAttempts = 1000 // Prevent infinite loop (typically needs 1-2 iterations)
+
+	for attempt := range maxAttempts {
+		var err error
+		shuffled, err = e.shuffler.Encode(shuffled)
+		if err != nil {
+			return nil, fmt.Errorf("shuffle failed on attempt %d: %w", attempt+1, err)
+		}
+
+		// Check if shuffled value is within pattern capacity
+		if shuffled < maxCapacityUint64 {
+			// Valid value found - we're done
+			break
+		}
+
+		// Value exceeds capacity, use it as input for next shuffle iteration
+		// This is the "cycle walking" - we walk through the cycle until we
+		// land in the valid range [0, maxCapacity)
+	}
+
+	if shuffled >= maxCapacityUint64 {
+		// This should be extremely rare (probability ~ (bitWidth - capacity) / bitWidth)
+		return nil, fmt.Errorf("cycle walking failed to find valid value after %d attempts (input: %d, capacity: %d)",
+			maxAttempts, val, maxCapacityUint64)
 	}
 
 	// Convert shuffled value back to PositiveInt
@@ -404,15 +466,28 @@ func (e *PhoneticEncoder) applyShuffle(number PositiveInt) (PositiveInt, error) 
 }
 
 // applyUnshuffle applies Feistel unshuffling to the decoded number if configured.
-// Returns the unshuffled number, or the original if no shuffler is configured.
+// Uses reverse cycle walking to properly decode values that were cycle-walked during encoding.
+// This is the inverse of applyShuffle and must mirror its cycle walking behavior.
+//
+// Note: If pattern capacity exceeds uint64, returns input unchanged (matching applyShuffle).
 func (e *PhoneticEncoder) applyUnshuffle(number PositiveInt) (PositiveInt, error) {
 	if e.shuffler == nil {
 		return number, nil
 	}
 
+	// Get maximum capacity for cycle walking
+	maxCapacity := e.patternEncoders[len(e.patternEncoders)-1].totalCombinations
+	maxUint64 := new(big.Int).SetUint64(math.MaxUint64)
+
+	// Check if capacity exceeds uint64 range
+	// If so, return input unchanged (matching applyShuffle behavior)
+	if maxCapacity.Cmp(maxUint64) > 0 {
+		return number, nil
+	}
+	maxCapacityUint64 := maxCapacity.Uint64()
+
 	// Check if number fits in uint64 for unshuffling
 	bigVal := number.BigInt()
-	maxUint64 := new(big.Int).SetUint64(math.MaxUint64)
 
 	if bigVal.Cmp(maxUint64) > 0 {
 		return nil, errors.New("decoded number too large for shuffling")
@@ -427,9 +502,31 @@ func (e *PhoneticEncoder) applyUnshuffle(number PositiveInt) (PositiveInt, error
 		val = bigVal.Uint64()
 	}
 
-	unshuffled, err := e.shuffler.Decode(val)
-	if err != nil {
-		return nil, fmt.Errorf("unshuffle failed: %w", err)
+	// Reverse cycle walking: repeatedly unshuffle until we get a value within capacity
+	// This mirrors the forward cycle walking in applyShuffle
+	unshuffled := val
+	const maxAttempts = 1000 // Match forward cycle walking limit
+
+	for attempt := range maxAttempts {
+		var err error
+		unshuffled, err = e.shuffler.Decode(unshuffled)
+		if err != nil {
+			return nil, fmt.Errorf("unshuffle failed on attempt %d: %w", attempt+1, err)
+		}
+
+		// Check if unshuffled value is within pattern capacity
+		if unshuffled < maxCapacityUint64 {
+			// Valid value found - this is our original input
+			break
+		}
+
+		// Value exceeds capacity, continue unshuffling
+		// This reverses the cycle walking from encoding
+	}
+
+	if unshuffled >= maxCapacityUint64 {
+		return nil, fmt.Errorf("reverse cycle walking failed after %d attempts (input: %d, capacity: %d)",
+			maxAttempts, val, maxCapacityUint64)
 	}
 
 	// Convert unshuffled value back to PositiveInt

--- a/pkg/encode_shuffle_capacity_test.go
+++ b/pkg/encode_shuffle_capacity_test.go
@@ -1,0 +1,278 @@
+package phonid_test
+
+import (
+	"math/big"
+	"testing"
+
+	. "github.com/iilei/phonid/pkg"
+)
+
+// TestMaxCapacityConsistentAcrossShuffleRounds verifies that the maximum
+// accepted value for encoding is the same regardless of shuffle configuration.
+// This test ensures cycle walking maintains consistent capacity limits.
+func TestMaxCapacityConsistentAcrossShuffleRounds(t *testing.T) {
+	// Create a simple config with known capacity
+	// CVCVC with 3 chars each: 3^5 = 243 combinations (0-242)
+	baseConfig := &PhonidConfig{
+		Patterns: []string{"CVCVC"},
+		Placeholders: PlaceholderMap{
+			Vowel:     RuneSet{'a', 'o', 'i'},
+			Consonant: RuneSet{'b', 'z', 'k'},
+		},
+	}
+
+	// Test with different shuffle configurations
+	testCases := []struct {
+		name   string
+		rounds int
+		seed   uint64
+	}{
+		{"no shuffle", 0, 0},
+		{"shuffle 3 rounds", 3, 12345},
+		{"shuffle 6 rounds", 6, 67890},
+		{"shuffle 10 rounds", 10, 99999},
+	}
+
+	expectedMaxValue := 242 // 243 - 1
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &PhonidConfig{
+				Patterns:     baseConfig.Patterns,
+				Placeholders: baseConfig.Placeholders,
+			}
+
+			// Add shuffle config if rounds > 0
+			if tc.rounds > 0 {
+				config.Shuffle = &ShuffleConfig{
+					BitWidth: 0, // auto-calculate
+					Rounds:   tc.rounds,
+					Seed:     tc.seed,
+				}
+			}
+
+			encoder, err := NewPhoneticEncoderSkipPreflight(config)
+			if err != nil {
+				t.Fatalf("Failed to create encoder: %v", err)
+			}
+
+			// Test that max value (242) succeeds
+			maxNum := NewPositiveInt(int64(expectedMaxValue))
+			word, err := encoder.Encode(maxNum)
+			if err != nil {
+				t.Errorf("Failed to encode max value %d: %v", expectedMaxValue, err)
+			} else {
+				t.Logf("Max value %d encoded successfully to: %s", expectedMaxValue, word)
+			}
+
+			// Test that max+1 (243) fails
+			overMaxNum := NewPositiveInt(int64(expectedMaxValue + 1))
+			_, err = encoder.Encode(overMaxNum)
+			if err == nil {
+				t.Errorf("Expected error encoding %d (beyond capacity), but succeeded", expectedMaxValue+1)
+			} else {
+				t.Logf("Correctly rejected value %d: %v", expectedMaxValue+1, err)
+			}
+
+			// Test additional values beyond capacity to ensure they all fail
+			testBeyondCapacity := []int64{243, 244, 250, 255, 256, 1000}
+			for _, val := range testBeyondCapacity {
+				num := NewPositiveInt(val)
+				_, err := encoder.Encode(num)
+				if err == nil {
+					t.Errorf("Expected error encoding %d (beyond capacity of %d), but succeeded",
+						val, expectedMaxValue)
+				}
+			}
+		})
+	}
+}
+
+// TestShufflerBitWidthVsPatternCapacity demonstrates cycle walking in action:
+// When shuffle rounds > 0, the bit width is rounded up (e.g., 8 bits for capacity 243),
+// but cycle walking ensures only values 0-242 are produced, not 0-255.
+func TestShufflerBitWidthVsPatternCapacity(t *testing.T) {
+	config := &PhonidConfig{
+		Patterns: []string{"CVCVC"}, // Capacity ~> 3^5 = 243
+		Placeholders: PlaceholderMap{
+			Vowel:     RuneSet{'a', 'o', 'i'},
+			Consonant: RuneSet{'b', 'z', 'k'},
+		},
+		Shuffle: &ShuffleConfig{
+			BitWidth: 0, // Will auto-calculate to 8 bits (since 2^7=128 < 243 < 2^8=256)
+			Rounds:   4,
+			Seed:     12345,
+		},
+	}
+
+	encoder, err := NewPhoneticEncoderSkipPreflight(config)
+	if err != nil {
+		t.Fatalf("Failed to create encoder: %v", err)
+	}
+
+	// Get pattern info to verify bit width calculation
+	patternInfo := encoder.GetPatternInfo()
+	if len(patternInfo) != 1 {
+		t.Fatalf("Expected 1 pattern, got %d", len(patternInfo))
+	}
+
+	trueCapacity := patternInfo[0].TrueCapacity.BigInt()
+	expectedCapacity := big.NewInt(242) // 243 - 1 (max encodable value)
+
+	if trueCapacity.Cmp(expectedCapacity) != 0 {
+		t.Fatalf("Expected capacity %s, got %s", expectedCapacity, trueCapacity)
+	}
+
+	t.Logf("Pattern capacity: 0-%s (243 total combinations)", trueCapacity)
+	t.Logf("Shuffler bit width: 8 bits (256 possible values)")
+	t.Logf("Cycle walking ensures: Only values 0-242 are produced after shuffling")
+
+	// Test: values in the "gap" (243-255) should be rejected at INPUT validation
+	gapValues := []int64{243, 244, 250, 255}
+	for _, val := range gapValues {
+		num := NewPositiveInt(val)
+		_, err := encoder.Encode(num)
+		if err == nil {
+			t.Errorf("BUG: Value %d should be rejected (beyond pattern capacity)", val)
+		} else {
+			t.Logf("✓ Correctly rejected input value %d: %v", val, err)
+		}
+	}
+
+	// Values within capacity should work - cycle walking handles intermediate values
+	validValues := []int64{0, 1, 100, 200, 240, 241, 242}
+	for _, val := range validValues {
+		num := NewPositiveInt(val)
+		word, err := encoder.Encode(num)
+		if err != nil {
+			t.Errorf("Failed to encode valid value %d: %v", val, err)
+			continue
+		}
+		t.Logf("✓ Successfully encoded valid value %d to: %s", val, word)
+
+		// Verify round-trip
+		decoded, err := encoder.Decode(word)
+		if err != nil {
+			t.Errorf("Failed to decode %s: %v", word, err)
+			continue
+		}
+
+		decodedVal, _ := decoded.Int64()
+		if decodedVal != val {
+			t.Errorf("Round-trip failed: encoded %d, decoded %d", val, decodedVal)
+		}
+	}
+}
+
+// TestRoundTripWithShuffleConsistency verifies that encoding and decoding
+// work correctly across all values in the pattern capacity with cycle walking enabled.
+func TestRoundTripWithShuffleConsistency(t *testing.T) {
+	config := &PhonidConfig{
+		Patterns: []string{"CVCVC"},
+		Placeholders: PlaceholderMap{
+			Vowel:     RuneSet{'a', 'o', 'i'},
+			Consonant: RuneSet{'b', 'z', 'k'},
+		},
+		Shuffle: &ShuffleConfig{
+			Rounds: 4,
+			Seed:   12345,
+		},
+	}
+
+	encoder, err := NewPhoneticEncoderSkipPreflight(config)
+	if err != nil {
+		t.Fatalf("Failed to create encoder: %v", err)
+	}
+
+	// Test a sample of values across the entire range
+	testValues := []int64{
+		0, 1, 2, 3, // Start
+		100, 120, 150, // Middle-low
+		200, 220, 240, 241, 242, // Near end (including edge cases)
+	}
+
+	for _, val := range testValues {
+		num := NewPositiveInt(val)
+		word, err := encoder.Encode(num)
+		if err != nil {
+			t.Errorf("Failed to encode %d: %v", val, err)
+			continue
+		}
+
+		decoded, err := encoder.Decode(word)
+		if err != nil {
+			t.Errorf("Failed to decode %s (from %d): %v", word, val, err)
+			continue
+		}
+
+		decodedVal, _ := decoded.Int64()
+		if decodedVal != val {
+			t.Errorf("Round-trip inconsistency: %d -> %s -> %d", val, word, decodedVal)
+		} else {
+			t.Logf("✓ Round-trip success: %d -> %s -> %d", val, word, decodedVal)
+		}
+	}
+
+	// Verify that 243 and above still fail at input validation
+	_, err = encoder.Encode(NewPositiveInt(243))
+	if err == nil {
+		t.Error("Value 243 should be rejected but was accepted")
+	} else {
+		t.Logf("✓ Value 243 correctly rejected: %v", err)
+	}
+}
+
+// TestCycleWalkingEdgeCases tests specific edge cases for cycle walking.
+func TestCycleWalkingEdgeCases(t *testing.T) {
+	config := &PhonidConfig{
+		Patterns: []string{"CVCVC"},
+		Placeholders: PlaceholderMap{
+			Vowel:     RuneSet{'a', 'o', 'i'},
+			Consonant: RuneSet{'b', 'z', 'k'},
+		},
+		Shuffle: &ShuffleConfig{
+			Rounds: 6, // More rounds to test cycle walking behavior
+			Seed:   999,
+		},
+	}
+
+	encoder, err := NewPhoneticEncoderSkipPreflight(config)
+	if err != nil {
+		t.Fatalf("Failed to create encoder: %v", err)
+	}
+
+	// Test boundary values that are most likely to trigger cycle walking
+	boundaryValues := []int64{
+		0,   // Minimum
+		1,   // Minimum + 1
+		128, // 2^7 (bit width boundary)
+		242, // Maximum (243 - 1)
+		241, // Maximum - 1
+		127, // 2^7 - 1
+	}
+
+	for _, val := range boundaryValues {
+		num := NewPositiveInt(val)
+
+		// Encode
+		word, err := encoder.Encode(num)
+		if err != nil {
+			t.Errorf("Failed to encode boundary value %d: %v", val, err)
+			continue
+		}
+
+		// Decode
+		decoded, err := encoder.Decode(word)
+		if err != nil {
+			t.Errorf("Failed to decode %s (from boundary value %d): %v", word, val, err)
+			continue
+		}
+
+		decodedVal, _ := decoded.Int64()
+		if decodedVal != val {
+			t.Errorf("Boundary value round-trip failed: %d -> %s -> %d", val, word, decodedVal)
+		} else {
+			t.Logf("✓ Boundary value %d: %s (round-trip OK)", val, word)
+		}
+	}
+}

--- a/pkg/preflight/goformat.go
+++ b/pkg/preflight/goformat.go
@@ -8,6 +8,13 @@ import (
 )
 
 // GoFormatter implements the Formatter interface for Go code output.
+// Note: This formatter only outputs preflight assertions, not configuration.
+// For full configuration including shuffle settings, use the TOML formatter.
+//
+// Shuffle Limitations:
+//
+//	Patterns with capacity > 18,446,744,073,709,551,615 (uint64 max) cannot be shuffled.
+//	When using such patterns, shuffle configuration should be omitted entirely.
 type GoFormatter struct{}
 
 // NewGoFormatter creates a new Go code formatter.

--- a/pkg/preflight/suggest.go
+++ b/pkg/preflight/suggest.go
@@ -10,9 +10,26 @@ import (
 
 const (
 	// midRangePercentage is the divisor for calculating mid-range value.
-	midRangePercentage = 2
-	LocalhostDecimal   = 2130706433
-	maxInt64           = math.MaxInt
+	midRangePercentage  = 2
+	LocalhostDecimal    = 2130706433
+	maxInt64            = math.MaxInt
+	ConfigHeaderComment = `
+Pattern Requirements:
+  - Pattern Length: Must be 5, 7, 11, 23, 29, 31, 37, 41, 43, or 47 characters
+    (e.g., CVCVC, CVCVCVC)
+  - Vowels (V): Length 5 needs ≥3 vowels; length 7+ needs ≥2 vowels
+  - Consonants (C): Need ≥3 characters (e.g., "bzk" or "bdfghjklmnprstvz")
+  - Shuffling: Ensure 128+ combinations for shuffle rounds ≥ 1 (automatically validated)
+
+Available Placeholders:
+  C = Consonants, V = Vowels, L = Liquids (l,m,n,r)
+  N = Nasals, S = Sibilants, F = Fricatives
+  X/Y/Z = Custom categories
+
+Shuffle Limitations:
+  Patterns with capacity > 18,446,744,073,709,551,615 (uint64 max) cannot be shuffled.
+  Shuffling will be automatically disabled for such patterns, and values will be
+  encoded in sequential order without permutation.`
 )
 
 type (

--- a/pkg/preflight/tomlformat.go
+++ b/pkg/preflight/tomlformat.go
@@ -28,7 +28,7 @@ const (
 type (
 	// TOMLConfig represents the full .phonidrc TOML structure.
 	TOMLConfig struct {
-		Shuffle   ShuffleConfig  `toml:"shuffle"`
+		Shuffle   *ShuffleConfig `toml:"shuffle,omitempty"` // Omitted if capacity > uint64 max
 		Phonetic  PhoneticConfig `toml:"phonetic"`
 		Preflight []Assertion    `toml:"preflight"`
 	}
@@ -101,8 +101,8 @@ func SuggestConfig(encoder *phonid.PhoneticEncoder, config *phonid.PhonidConfig)
 		return "", fmt.Errorf("failed to generate suggestions: %w", err)
 	}
 
-	// Build full config
-	tomlConfig := buildTOMLConfig(config, assertions)
+	// Build full config (pass encoder for capacity checking)
+	tomlConfig := buildTOMLConfig(config, assertions, encoder)
 	capacityInt := encoder.GetSmallestPatternCapacity()
 	if capacityInt < 0 {
 		return "", errors.New("encoder capacity cannot be negative")
@@ -141,8 +141,8 @@ func FormatTOMLWithSuggestions(
 		}
 	}
 
-	// Build full config
-	tomlConfig := buildTOMLConfig(config, *suggestions)
+	// Build full config (pass encoder for capacity checking)
+	tomlConfig := buildTOMLConfig(config, *suggestions, encoder)
 	capacityInt := encoder.GetSmallestPatternCapacity()
 	if capacityInt < 0 {
 		return "", errors.New("encoder capacity cannot be negative")
@@ -165,23 +165,38 @@ func FormatTOMLWithSuggestions(
 
 // buildTOMLConfig constructs a TOMLConfig from PhonidConfig and assertions.
 // Uses shuffle settings from config if present, otherwise uses defaults.
-func buildTOMLConfig(config *phonid.PhonidConfig, assertions AssertionTable) *TOMLConfig {
+// Omits shuffle config entirely if pattern capacity exceeds uint64 max (shuffling not supported).
+func buildTOMLConfig(
+	config *phonid.PhonidConfig,
+	assertions AssertionTable,
+	encoder *phonid.PhoneticEncoder,
+) *TOMLConfig {
 	placeholders := make(map[string]string)
 	for k, v := range config.Placeholders {
 		placeholders[string(k)] = string(v)
 	}
 
-	// Extract shuffle config from input or use defaults
-	shuffleConfig := ShuffleConfig{
-		Rounds: defaultRounds,
-		Seed:   defaultSeed,
-	}
+	// Check if shuffling is possible (capacity must fit in uint64)
+	var shuffleConfig *ShuffleConfig
+	patterns := encoder.GetPatternInfo()
+	if len(patterns) > 0 {
+		largestPattern := patterns[len(patterns)-1]
+		// Only include shuffle config if capacity fits in uint64 range
+		if !largestPattern.ExceedsInt64 {
+			// Extract shuffle config from input or use defaults
+			shuffleConfig = &ShuffleConfig{
+				Rounds: defaultRounds,
+				Seed:   defaultSeed,
+			}
 
-	// If config has shuffle settings, use them
-	if config.Shuffle != nil {
-		shuffleConfig.Rounds = config.Shuffle.Rounds
-		//#nosec G115 -- Seed is validated by ShuffleConfig.Validate() to be <= MaxSafeSeed (int64 max)
-		shuffleConfig.Seed = int(config.Shuffle.Seed)
+			// If config has shuffle settings, use them
+			if config.Shuffle != nil {
+				shuffleConfig.Rounds = config.Shuffle.Rounds
+				//#nosec G115 -- Seed is validated by ShuffleConfig.Validate() to be <= MaxSafeSeed (int64 max)
+				shuffleConfig.Seed = int(config.Shuffle.Seed)
+			}
+		}
+		// If ExceedsInt64, shuffleConfig remains nil and will be omitted from TOML
 	}
 
 	return &TOMLConfig{
@@ -198,6 +213,22 @@ func buildTOMLConfig(config *phonid.PhonidConfig, assertions AssertionTable) *TO
 func addInlineComments(tomlStr string, assertions AssertionTable, capacity uint64) string {
 	lines := strings.Split(tomlStr, "\n")
 	var result strings.Builder
+
+	// Add header comment at the very top
+	fmt.Fprintf(&result, "# Output of 'phonid preflight --suggest'\n")
+	fmt.Fprintf(&result, "#\n")
+	fmt.Fprintf(&result, "# Capacity per word: %s combinations (0-%d)\n", formatCapacity(capacity), capacity)
+	fmt.Fprintf(&result, "#\n")
+
+	// Add ConfigHeaderComment as TOML comments
+	for line := range strings.SplitSeq(strings.Trim(ConfigHeaderComment, "\n"), "\n") {
+		if line == "" {
+			fmt.Fprintf(&result, "#\n")
+		} else {
+			fmt.Fprintf(&result, "# %s\n", line)
+		}
+	}
+	fmt.Fprintf(&result, "\n")
 
 	// Find where preflight section starts
 	preflightStart := -1
@@ -216,12 +247,6 @@ func addInlineComments(tomlStr string, assertions AssertionTable, capacity uint6
 		}
 	}
 
-	// Add header comment before preflight section
-	fmt.Fprintf(&result, "# Output of 'phonid preflight --suggest'\n")
-	fmt.Fprintf(&result, "#\n")
-	fmt.Fprintf(&result, "# Capacity per word: %s combinations (0-%d)\n", formatCapacity(capacity), capacity)
-
-	fmt.Fprintf(&result, "#\n")
 	fmt.Fprintf(&result, "# Suggested preflight checks:\n\n")
 	// Process preflight section with inline comments
 	assertionIdx := 0


### PR DESCRIPTION
Implements Cycle Walking for small numbers,
prevents shuffle for > uint64