### PR TITLE
feat!: auto-detect numeric base for CLI number input

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ With config file:
 ./dist/phonid*/phonid --config ./public_presets/.proquint.phonidrc.toml 1337
 ```
 
-Hex input is accepted with `0x` / `0X`:
+Prefixed base input is accepted with `0x` / `0X` (hex), `0b` / `0B` (binary), and `0o` / `0O` (octal):
 
 ```sh
 ./dist/phonid*/phonid 0x539

--- a/cmd/phonid/root.go
+++ b/cmd/phonid/root.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -15,7 +14,6 @@ import (
 )
 
 const (
-	cliHexBase         = 16
 	presetProQuint     = "proquint"
 	presetProQuintTiny = "proquint-tiny"
 	presetProQuintSHA  = "proquint-sha256"
@@ -153,17 +151,10 @@ func newCLIEncoder(config *phonid.PhonidConfig, checks []phonid.PreflightCheck) 
 }
 
 func parseCLIPositiveInt(input string) (phonid.PositiveInt, error) {
-	if !strings.HasPrefix(input, "0x") && !strings.HasPrefix(input, "0X") {
-		return phonid.ParsePositiveInt(input)
-	}
-
-	hexDigits := input[2:]
-	if hexDigits == "" {
-		return nil, fmt.Errorf("invalid number: %s", input)
-	}
-
-	value := new(big.Int)
-	if _, ok := value.SetString(hexDigits, cliHexBase); !ok {
+	// Auto-detect base from common prefixes: 0x (hex), 0b (binary), 0o (octal).
+	// Without a prefix, values are parsed as decimal.
+	value, ok := new(big.Int).SetString(input, 0)
+	if !ok || value.Sign() < 0 {
 		return nil, fmt.Errorf("invalid number: %s", input)
 	}
 

--- a/cmd/phonid/root_test.go
+++ b/cmd/phonid/root_test.go
@@ -52,6 +52,36 @@ func TestEncodeCommand_AcceptsUppercaseHexPrefix(t *testing.T) {
 	}
 }
 
+func TestEncodeCommand_AcceptsLowercaseBinaryPrefix(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	resetCLIState(t)
+	rootCmd.SetOut(stdout)
+
+	rootCmd.SetArgs([]string{"0o2471"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "babab-bihun" {
+		t.Fatalf("encode output = %q, want %q", got, "babab-bihun")
+	}
+}
+
+func TestEncodeCommand_AcceptsLowercaseOctalPrefix(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	resetCLIState(t)
+	rootCmd.SetOut(stdout)
+
+	rootCmd.SetArgs([]string{"0o52"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "babab-babop" {
+		t.Fatalf("encode output = %q, want %q", got, "babab-babop")
+	}
+}
+
 func TestEncodeCommand_InvalidHexInput(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	resetCLIState(t)
@@ -81,6 +111,42 @@ func TestEncodeCommand_MissingHexDigits(t *testing.T) {
 		t.Fatal("rootCmd.Execute() error = nil, want error")
 	}
 	if !strings.Contains(err.Error(), "invalid number: 0x") {
+		t.Fatalf("error = %q, want invalid number context", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+}
+
+func TestEncodeCommand_InvalidBinaryInput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	resetCLIState(t)
+	rootCmd.SetOut(stdout)
+
+	rootCmd.SetArgs([]string{"0b102"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("rootCmd.Execute() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid number: 0b102") {
+		t.Fatalf("error = %q, want invalid number context", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+}
+
+func TestEncodeCommand_InvalidOctalInput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	resetCLIState(t)
+	rootCmd.SetOut(stdout)
+
+	rootCmd.SetArgs([]string{"0o89"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("rootCmd.Execute() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid number: 0o89") {
 		t.Fatalf("error = %q, want invalid number context", err)
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "" {


### PR DESCRIPTION
 * parse CLI input with Go base auto-detection (`0x`, `0b`, `0o`)
 * simplify parser to a single bigint parse path
 * update tests and docs for prefixed-base support
 * BREAKING-CHANGE: numeric parsing now uses base auto-detection semantics. Inputs with leading zeroes may be interpreted differently (for example, `052` is treated as octal). Users *should* pass plain decimal (no leading zero) or explicit prefixes (`0x`, `0b`, `0o`).